### PR TITLE
Pin setuptools version to keep pkg_resources for ITK

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - starfile
   - scikit-image
   - pip
+  - setuptools<81
   - pip:
       - edt
       - umap-learn


### PR DESCRIPTION
ITK imports pkg_resources, which was removed in newer setuptools releases, cryosiam CLI (e.g., --version) working